### PR TITLE
Utiles v7.1 server fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ___
 
+## 0.7.1 (2025-01-09)
+
+- fix axum 8 new routing paths
+
+___
+
 ## 0.7.0 (2025-01-09)
 
 - **NO UNWRAPPING!** there is no unwrapping in utiles!

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "pyutiles"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "geojson",
  "jiff",
@@ -2851,7 +2851,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utiles"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2900,7 +2900,7 @@ dependencies = [
 
 [[package]]
 name = "utiles-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "fast_hilbert",
  "serde",
@@ -2910,7 +2910,7 @@ dependencies = [
 
 [[package]]
 name = "utiles-dev"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "geojson",
@@ -2923,7 +2923,7 @@ dependencies = [
 
 [[package]]
 name = "utiles-oxipng"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 authors = [
   "Jesse Rubin <jessekrubin@gmail.com>",
   "Dan Costello <dan.costello2@gmail.com>",

--- a/crates/utiles/Cargo.toml
+++ b/crates/utiles/Cargo.toml
@@ -63,7 +63,7 @@ tower = { version = "0.5.2", features = ["timeout"] }
 tower-http = { version = "0.6.1", features = ["trace", "timeout", "add-extension", "util", "request-id", "compression-gzip", "compression-zstd", "async-compression"] }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["fmt", "json", "env-filter"] }
-utiles-core = { path = "../utiles-core", version = "0.7.0" }
+utiles-core = { path = "../utiles-core", version = "0.7.1" }
 walkdir.workspace = true
 xxhash-rust = { workspace = true, features = ["const_xxh3", "const_xxh64", "const_xxh32", "xxh3", "xxh64", "xxh32"] }
 

--- a/crates/utiles/src/server/mod.rs
+++ b/crates/utiles/src/server/mod.rs
@@ -146,9 +146,12 @@ pub async fn utiles_serve(cfg: UtilesServerConfig) -> UtilesResult<()> {
         .route("/cfg", get(get_cfg))
         .route("/uitiles", get(uitiles))
         .route("/datasets", get(get_datasets))
-        .route("/tiles/:dataset/tile.json", get(get_dataset_tilejson))
-        .route("/tiles/:dataset/:quadkey", get(get_dataset_tile_quadkey))
-        .route("/tiles/:dataset/:z/:x/:y", get(get_dataset_tile_zxy))
+        .route("/tiles/{dataset}/tile.json", get(get_dataset_tilejson))
+        .route(
+            "/tiles/{dataset}/qk/{quadkey}",
+            get(get_dataset_tile_quadkey),
+        )
+        .route("/tiles/{dataset}/{z}/{x}/{y}", get(get_dataset_tile_zxy))
         .layer(middleware)
         .with_state(shared_state) // shared app/server state
         .fallback(four_o_four); // 404
@@ -161,10 +164,6 @@ pub async fn utiles_serve(cfg: UtilesServerConfig) -> UtilesResult<()> {
         .await?;
     Ok(())
 }
-// =============
-// REQUEST ID
-// =============
-
 // =====================================================================
 // ROUTES ~ ROUTES ~ ROUTES ~ ROUTES ~ ROUTES ~ ROUTES ~ ROUTES ~ ROUTES
 // =====================================================================


### PR DESCRIPTION
# ai word salad

This pull request includes several updates and bug fixes to the `utiles` project. The most important changes involve updating the version numbers, fixing routing paths in the server module, and maintaining the changelog.

Version updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L12-R12): Updated the version from `0.7.0` to `0.7.1`.
* [`crates/utiles/Cargo.toml`](diffhunk://#diff-8807a102444d43eea7d910d2750f3e609793e92e7964e94f5e6f086f2ff70d26L66-R66): Updated the `utiles-core` dependency version from `0.7.0` to `0.7.1`.

Bug fixes:

* [`crates/utiles/src/server/mod.rs`](diffhunk://#diff-74f5ecdf4ad8a808633ae8092c53b525166754cc469956d0dd00db5f9781d3d2L149-R154): Fixed routing paths for `get_dataset_tilejson`, `get_dataset_tile_quadkey`, and `get_dataset_tile_zxy` functions to use curly braces `{}` instead of colons `:`.

Documentation:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R14): Added a new entry for version `0.7.1`, detailing the fix for the new routing paths in `axum 8`.