### PR TITLE
Web geo bounds mess

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -92,11 +92,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
@@ -129,7 +130,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -155,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "async-sqlite"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a86b242350ea4ff78866f8253182dd49dddb1decd4e596b918098ed250fd2"
+checksum = "60659f08ccb3a20c15af150ae736cde366fa0657246be9d194affb0149be188f"
 dependencies = [
  "crossbeam-channel",
  "futures-channel",
@@ -173,7 +174,7 @@ checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -289,7 +290,7 @@ checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -327,9 +328,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bitstream-io"
@@ -370,15 +371,15 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c360505aed52b7ec96a3636c3f039d99103c37d1d9b4f7a8c743d3ea9ffcd03b"
+checksum = "73848a43c5d63a1251d17adf6c2bf78aa94830e60a335a95eeea45d6ba9e1e4d"
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
@@ -400,9 +401,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "cast"
@@ -412,9 +413,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.7"
+version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
+checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
 dependencies = [
  "jobserver",
  "libc",
@@ -466,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.28"
+version = "4.5.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
+checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -476,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -496,7 +497,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -633,9 +634,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-common"
@@ -678,7 +679,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -809,6 +810,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,7 +898,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -966,7 +973,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1016,26 +1035,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1104,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
 
 [[package]]
 name = "httpdate"
@@ -1116,9 +1129,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1174,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "image-webp"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e031e8e3d94711a9ccb5d6ea357439ef3dcbed361798bd4071dc4d9793fbe22f"
+checksum = "b77d01e822461baa8409e156015a1d91735549f0f2c17691bd2d996bef238f7f"
 dependencies = [
  "byteorder-lite",
  "quick-error",
@@ -1196,12 +1209,12 @@ checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown",
  "rayon",
 ]
 
@@ -1232,18 +1245,18 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi 0.4.0",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1284,9 +1297,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jiff"
-version = "0.1.29"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c04ef77ae73f3cf50510712722f0c4e8b46f5aaa1bf5ffad2ae213e6495e78e5"
+checksum = "ba926fdd8e5b5e7f9700355b0831d8c416afe94b014b1023424037a187c9c582"
 dependencies = [
  "jiff-tzdb-platform",
  "log",
@@ -1328,9 +1341,9 @@ checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1396,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b9569d2f74e257076d8c6bfa73fb505b46b851e51ddaecc825944aa3bed17fa"
+checksum = "cf78f52d400cf2d84a3a973a78a592b4adc535739e0a5597a0da6f0c357adc75"
 dependencies = [
  "arbitrary",
  "cc",
@@ -1416,16 +1429,16 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "libc",
  "redox_syscall",
 ]
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "ad8935b44e7c13394a179a438e0cebba0fe08fe01b54f152e29a93b5cf993fd4"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1456,9 +1469,9 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "loop9"
@@ -1542,9 +1555,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -1557,7 +1570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -1622,7 +1635,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1682,9 +1695,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "oorandom"
@@ -1774,7 +1787,7 @@ dependencies = [
  "regex",
  "regex-syntax 0.7.5",
  "structmeta",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1892,9 +1905,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -1915,7 +1928,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
 dependencies = [
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1965,7 +1978,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1978,7 +1991,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2054,7 +2067,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -2133,7 +2146,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -2197,11 +2210,11 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "1c6d5e5acb6f6129fe3f7ba0a7fc77bca1942cb568535e18e7bc40262baf3110"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -2217,17 +2230,17 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "0.38.43"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2242,9 +2255,9 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "same-file"
@@ -2278,7 +2291,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2418,9 +2431,9 @@ dependencies = [
 
 [[package]]
 name = "sqlite-hashes"
-version = "0.7.8"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03cb5a95dca257c912e3fa49258150ed95facccb20edbff2cf6e1a74335beff"
+checksum = "738ea43e6503b10148d455b0e9439910de736def570a0e2c7dc6b99c493aadfb"
 dependencies = [
  "digest",
  "hex",
@@ -2444,7 +2457,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2455,29 +2468,29 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "ce1475c515a4f03a8a7129bb5228b81a781a86cb0b3fbbc19e1c556d491a401f"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "9688894b43459159c82bfa5a5fa0435c19cbe3c9b427fa1dd7b1ce0c279b18a7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2502,9 +2515,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.95"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2578,7 +2591,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2589,7 +2602,7 @@ checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2661,7 +2674,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2690,9 +2703,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2711,9 +2724,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
  "serde",
@@ -2745,7 +2758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 dependencies = [
  "async-compression",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "bytes",
  "futures-core",
  "http",
@@ -2792,7 +2805,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2855,9 +2868,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-width"
@@ -2997,11 +3010,11 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
+checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.1",
 ]
 
 [[package]]
@@ -3017,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "varint-rs"
@@ -3062,35 +3075,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.99"
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3098,28 +3121,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3322,11 +3348,20 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.22"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
+checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -3362,7 +3397,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ repository = "https://github.com/jessekrubin/utiles"
 [workspace.dependencies]
 ahash = "0.8.11"
 anyhow = "1.0.95"
-async-sqlite = { version = "0.4.0", features = ["bundled", "functions", "trace"] }
+async-sqlite = { version = "0.5.0", features = ["bundled", "functions", "trace"] }
 async-trait = "0.1.86"
 axum = { version = "0.8.1", features = ["tokio", "json", "macros"] }
 axum-extra = "0.10.0"
@@ -40,7 +40,7 @@ image = "0.25.5"
 imagesize = "0.13.0"
 indicatif = "0.17.11"
 indoc = "2.0.5"
-jiff = "0.1.29"
+jiff = "0.2.0"
 json-patch = "3.0.1"
 md-5 = "0.10.6"
 noncrypto-digests = "0.3.2"
@@ -49,13 +49,13 @@ owo-colors = { version = "4.1.0", features = ["supports-color"] }
 pmtiles = { version = "0.11.0", features = ["mmap-async-tokio", "tilejson"] }
 pyo3 = "0.23.4"
 pyo3-build-config = "0.23.2"
-rusqlite = { version = "0.32.0", features = ["bundled", "vtab", "blob"] }
+rusqlite = { version = "0.33.0", features = ["bundled", "vtab", "blob"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.138", features = ["preserve_order"] }
 size = { version = "=0.5.0-preview2", features = ["default"] }
-sqlite-hashes = { version = "0.7.8", default-features = false, features = ["hex", "window", "md5", "fnv", "xxhash"] }
-strum = { version = "0.26.3", features = ["derive"] }
-strum_macros = "0.26.3"
+sqlite-hashes = { version = "0.8.0", default-features = false, features = ["hex", "window", "md5", "fnv", "xxhash"] }
+strum = { version = "0.27.0", features = ["derive"] }
+strum_macros = "0.27.0"
 thiserror = "2.0.11"
 tilejson = "0.4.1"
 tokio = { version = "1.42.0", features = ["full"] }

--- a/crates/utiles-core/src/bbox.rs
+++ b/crates/utiles-core/src/bbox.rs
@@ -49,21 +49,28 @@ impl From<(f64, f64, f64, f64)> for BBox {
     }
 }
 
+impl From<BBox> for (f64, f64, f64, f64) {
+    fn from(bbox: BBox) -> Self {
+        (bbox.west, bbox.south, bbox.east, bbox.north)
+    }
+}
+
 impl From<(i32, i32, i32, i32)> for BBox {
     fn from(bbox: (i32, i32, i32, i32)) -> Self {
         // convert to f64
-        let bbox = (
+        (
             f64::from(bbox.0),
             f64::from(bbox.1),
             f64::from(bbox.2),
             f64::from(bbox.3),
-        );
-        BBox {
-            north: bbox.0,
-            south: bbox.1,
-            east: bbox.2,
-            west: bbox.3,
-        }
+        )
+            .into()
+        // BBox {
+        //     north: bbox.0,
+        //     south: bbox.1,
+        //     east: bbox.2,
+        //     west: bbox.3,
+        // }
     }
 }
 

--- a/crates/utiles-core/src/fns.rs
+++ b/crates/utiles-core/src/fns.rs
@@ -661,32 +661,6 @@ pub fn lnglat2tile_frac(lng: f64, lat: f64, z: u8) -> (f64, f64, u8) {
     (x, y, z)
 }
 
-// fn lnglat2tile_frac_old(lng: f64, lat: f64, z: u8) -> (f64, f64, u8) {
-//     // let n = 2.0_f64.powi(z as i32);
-//     // let x = n * ((lng + 180.0) / 360.0);
-//     // let lat_rad = lat.to_radians();
-//     // let y = n * (1.0 - (lat_rad.sinh().atanh() / std::f64::consts::PI)) / 2.0;
-//     // (x, y, z)
-//     let sin = (lat * DEG2RAD).sin();
-//     let z2 = 2f64.powi(i32::from(z));
-//     let mut x = z2 * (lng / 360.0 + 0.5);
-//     let y = z2 * (0.5 - (0.25 * ((1.0 + sin) / (1.0 - sin)).ln()) / PI);
-//     // Wrap Tile X
-//     x %= z2;
-//     if x < 0.0 {
-//         x += z2;
-//     }
-//
-//     (x, y, z)
-// }
-// fn lnglat2tile_frac(lon: f64, lat: f64, zoom: u8) -> (f64, f64, u8) {
-//     let n = 2.0_f64.powi(zoom as i32);
-//     let x = n * ((lon + 180.0) / 360.0);
-//     let lat_rad = lat.to_radians();
-//     let y = n * (1.0 - (lat_rad.sinh().atanh() / std::f64::consts::PI)) / 2.0;
-//     (x, y, zoom)
-// }
-
 /// Return the bounding tile for a bounding box.
 ///
 /// # Errors

--- a/crates/utiles-core/src/lib.rs
+++ b/crates/utiles-core/src/lib.rs
@@ -34,6 +34,7 @@ pub use tile_strfmt::{TileStringFormat, TileStringFormatter};
 pub use tile_zbox::TileZBox;
 #[doc(inline)]
 pub use traits::{Coord2dLike, IsOk, LngLatLike, TileChildren1, TileParent};
+pub use web_geo_bounds::web_geo_bounds_union;
 pub use zoom::*;
 pub mod bbox;
 pub mod constants;
@@ -66,44 +67,47 @@ pub mod tile_type;
 pub mod tile_zbox;
 mod tilecrz;
 mod traits;
+mod web_geo_bounds;
 pub mod zoom;
+mod macros;
 
+// pub use macros::{point2d, utile, utile_yup};
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
-
-/// Tile macro to create a new tile.
-///  - do you need this? probably not
-///  - Did I write to figure out how to write a macro? yes
-#[macro_export]
-macro_rules! utile {
-    ($x:expr, $y:expr, $z:expr) => {
-        Tile::new($x, $y, $z)
-    };
-}
-
-#[macro_export]
-macro_rules! utile_yup {
-    ($x:expr, $y:expr, $z:expr) => {
-        Tile::new($x, flipy($y, $z), $z)
-    };
-}
-
-/// point2d macro to create a new point.
-/// Replacement for coord! macro from geo-types
-///
-/// # Examples
-///
-/// ```
-/// use utiles_core::{point2d, Point2d};
-/// let p = point2d!{ x: 1.0, y: 2.0 };
-/// assert_eq!(p.x(), 1.0);
-/// assert_eq!(p.y(), 2.0);
-/// ```
-#[macro_export]
-macro_rules! point2d {
-    { x: $x:expr, y: $y:expr } => {
-        Point2d::new($x, $y)
-    };
-}
+//
+// /// Tile macro to create a new tile.
+// ///  - do you need this? probably not
+// ///  - Did I write to figure out how to write a macro? yes
+// #[macro_export]
+// macro_rules! utile {
+//     ($x:expr, $y:expr, $z:expr) => {
+//         Tile::new($x, $y, $z)
+//     };
+// }
+//
+// #[macro_export]
+// macro_rules! utile_yup {
+//     ($x:expr, $y:expr, $z:expr) => {
+//         Tile::new($x, flipy($y, $z), $z)
+//     };
+// }
+//
+// /// point2d macro to create a new point.
+// /// Replacement for coord! macro from geo-types
+// ///
+// /// # Examples
+// ///
+// /// ```
+// /// use utiles_core::{point2d, Point2d};
+// /// let p = point2d!{ x: 1.0, y: 2.0 };
+// /// assert_eq!(p.x(), 1.0);
+// /// assert_eq!(p.y(), 2.0);
+// /// ```
+// #[macro_export]
+// macro_rules! point2d {
+//     { x: $x:expr, y: $y:expr } => {
+//         Point2d::new($x, $y)
+//     };
+// }
 
 pub mod prelude {
     pub use crate::flipy;

--- a/crates/utiles-core/src/lib.rs
+++ b/crates/utiles-core/src/lib.rs
@@ -47,6 +47,7 @@ pub mod geostats;
 pub mod lnglat;
 pub mod parsing;
 
+mod macros;
 mod merge;
 mod parent;
 #[cfg(feature = "pmtiles")]
@@ -69,7 +70,6 @@ mod tilecrz;
 mod traits;
 mod web_geo_bounds;
 pub mod zoom;
-mod macros;
 
 // pub use macros::{point2d, utile, utile_yup};
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/utiles-core/src/lib.rs
+++ b/crates/utiles-core/src/lib.rs
@@ -23,7 +23,7 @@ pub use bbox::{geobbox_merge, BBox};
 pub use errors::{UtilesCoreError, UtilesCoreResult};
 #[doc(inline)]
 pub use gdal::geotransform2optzoom;
-pub use lnglat::LngLat;
+pub use lnglat::{wrap_lon, LngLat};
 pub use point::{Point2d, Point3d};
 pub use textiles::*;
 #[doc(inline)]

--- a/crates/utiles-core/src/lnglat.rs
+++ b/crates/utiles-core/src/lnglat.rs
@@ -144,3 +144,10 @@ impl FromStr for LngLat {
         Ok(LngLat::new(x, y))
     }
 }
+
+/// Wraps a longitude value to the range [-180, 180].
+#[must_use]
+#[inline]
+pub fn wrap_lon(lon: f64) -> f64 {
+    (lon + 180.0).rem_euclid(360.0) - 180.0
+}

--- a/crates/utiles-core/src/macros.rs
+++ b/crates/utiles-core/src/macros.rs
@@ -1,0 +1,35 @@
+
+/// Tile macro to create a new tile.
+///  - do you need this? probably not
+///  - Did I write to figure out how to write a macro? yes
+#[macro_export]
+macro_rules! utile {
+    ($x:expr, $y:expr, $z:expr) => {
+        Tile::new($x, $y, $z)
+    };
+}
+
+#[macro_export]
+macro_rules! utile_yup {
+    ($x:expr, $y:expr, $z:expr) => {
+        Tile::new($x, flipy($y, $z), $z)
+    };
+}
+
+/// point2d macro to create a new point.
+/// Replacement for coord! macro from geo-types
+///
+/// # Examples
+///
+/// ```
+/// use utiles_core::{point2d, Point2d};
+/// let p = point2d!{ x: 1.0, y: 2.0 };
+/// assert_eq!(p.x(), 1.0);
+/// assert_eq!(p.y(), 2.0);
+/// ```
+#[macro_export]
+macro_rules! point2d {
+    { x: $x:expr, y: $y:expr } => {
+        Point2d::new($x, $y)
+    };
+}

--- a/crates/utiles-core/src/macros.rs
+++ b/crates/utiles-core/src/macros.rs
@@ -1,4 +1,3 @@
-
 /// Tile macro to create a new tile.
 ///  - do you need this? probably not
 ///  - Did I write to figure out how to write a macro? yes

--- a/crates/utiles-core/src/web_geo_bounds.rs
+++ b/crates/utiles-core/src/web_geo_bounds.rs
@@ -1,0 +1,296 @@
+/// A bounding box in (west, south, east, north) format.
+/// Note that `west > east` implies crossing the antimeridian.
+pub(crate) type TBounds = (f64, f64, f64, f64);
+
+/// Computes a "union" bounding box that encloses all input bboxes.
+/// The resulting bbox can cross the antimeridian (i.e. `west > east`).
+///
+/// Special cases:
+/// - If there is only **one** bbox, we return it exactly (even if it crosses the antimeridian).
+/// - If there are no bboxes, we return (0, 0, 0, 0) or you could choose to return an `Option`.
+///
+/// Examples:
+///
+/// Multiple bboxes that some of which cross the antimeridian:
+/// ```
+/// use utiles_core::web_geo_bounds_union;
+/// let bboxes = vec![
+///    (100.0, -5.0, 120.0, 10.0),
+///    (170.0, -10.0, -170.0, 5.0), // crosses AM
+///    (-160.0, -20.0, -100.0, 5.0),
+/// ];
+/// let bbox = web_geo_bounds_union(&bboxes).unwrap();
+/// assert_eq!(bbox, (100.0, -20.0, 120.0, 10.0));
+/// ```
+///
+/// Single bbox that crosses the antimeridian:
+/// ```
+/// use utiles_core::web_geo_bounds_union;
+/// let bboxes = vec![(170.0, -10.0, -170.0, 5.0)];
+/// let bbox = web_geo_bounds_union(&bboxes).unwrap();
+/// assert_eq!(bbox, (170.0, -10.0, -170.0, 5.0));
+/// ```
+///
+/// Two bboxes that do not cross the antimeridian:
+/// ```
+/// use utiles_core::web_geo_bounds_union;
+/// let bboxes = vec![
+///   (100.0, -5.0, 120.0, 10.0),
+///   (110.0, -10.0, 130.0, 5.0),
+/// ];
+///
+/// let bbox = web_geo_bounds_union(&bboxes).unwrap();
+/// assert_eq!(bbox, (100.0, -10.0, 130.0, 10.0));
+/// ```
+pub fn web_geo_bounds_union(bboxes: &[TBounds]) -> Option<TBounds> {
+    // collect:
+    // 1) the min/max lat as that is going to be our min/max lat...
+    // AND
+    // 2) convert each bbox into one or two longitude ranges
+    let (south, north, mut ranges) = collect_minmax_lat_and_lng_ranges(bboxes);
+
+
+
+    // Edge case: no bboxes
+    if ranges.is_empty() {
+        return None;
+    }
+
+    println!("ranges: {:?}", ranges);
+    // merge the ranges that overlap or are adjacent into contiguous ranges
+    let merged = merge_lng_ranges(&mut ranges);
+
+    println!("merged: {:?}", merged);
+
+    // Return if there is only one range...
+    if merged.len() == 1 {
+        let (final_west, final_east) = merged[0];
+        return Some((final_west, south, final_east, north));
+    }
+
+    // Find the largest void/gap/hole in the merged ranges, as that is the
+    // arc that is opposite of our desired bounds
+    let (gap_start, gap_end) = largest_lng_range_hole(&merged);
+    let west = wrap_lon(gap_end);
+    let east = wrap_lon(gap_start);
+    Some((west, south, east, north))
+}
+fn wrap_lon(lon: f64) -> f64 {
+    (lon + 180.0).rem_euclid(360.0) - 180.0
+}
+
+// fn gather_lat_and_intervals(bboxes: &[BBox]) -> (f64, f64, Vec<(f64, f64)>) {
+// }
+fn collect_minmax_lat_and_lng_ranges(bboxes: &[TBounds]) -> (f64, f64, Vec<(f64, f64)>) {
+    let mut min_lat = f64::INFINITY;
+    let mut max_lat = f64::NEG_INFINITY;
+    let mut intervals = Vec::new();
+
+    for &(west, south, east, north) in bboxes {
+        println!("west: {}, south: {}, east: {}, north: {}", west, south, east, north);
+        // Update latitude boundaries
+        min_lat = min_lat.min(south);
+        max_lat = max_lat.max(north);
+
+        // Convert to intervals
+        if west > east {
+            // Crosses the antimeridian
+            intervals.push((west, 180.0));
+            intervals.push((-180.0, east));
+        } else {
+            intervals.push((west, east));
+        }
+    }
+    (min_lat, max_lat, intervals)
+    // bboxes.iter().fold(
+    //     (f64::INFINITY, f64::NEG_INFINITY, Vec::new()),
+    //     |(min_lat, max_lat, mut intervals), &(west, south, east, north)| {
+    //         Update latitude boundaries
+            // let new_min_lat = min_lat.min(south);
+            // let new_max_lat = max_lat.max(north);
+            //
+            // Convert to intervals (handle crossing the antimeridian)
+            // if west > east {
+            //     intervals.push((west, 180.0));
+            //     intervals.push((-180.0, east));
+            // } else {
+            //     intervals.push((west, east));
+            // }
+            //
+            // (new_min_lat, new_max_lat, intervals)
+        // },
+    // )
+}
+fn merge_lng_ranges(intervals: &mut Vec<(f64, f64)>) -> Vec<(f64, f64)> {
+    // Sort by start
+    intervals.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    println!("sorted intervals: {:?}", intervals);
+    // Merge
+    let mut merged = Vec::with_capacity(intervals.len());
+    for &(start, end) in intervals.iter() {
+        if let Some(last) = merged.last_mut() {
+            let (prev_start, prev_end) = *last;
+            // Overlapping or contiguous intervals
+            if start <= prev_end {
+                let new_end = prev_end.max(end);
+                *last = (prev_start, new_end);
+            } else {
+                merged.push((start, end));
+            }
+        } else {
+            merged.push((start, end));
+        }
+    }
+    merged
+}
+/// Gathers min/max latitude, and converts each bbox into one or two longitude intervals.
+/// Returns (`min_lat`, `max_lat`, Vec<(start, end)>).
+fn collect_minmax_lat_and_lng_ranges2(
+    bboxes: &[TBounds],
+) -> (f64, f64, Vec<(f64, f64)>) {
+    bboxes.iter().fold(
+        (f64::INFINITY, f64::NEG_INFINITY, Vec::new()),
+        |(min_lat, max_lat, mut ranges), &(west, south, east, north)| {
+            // Update latitude boundaries
+            let new_min_lat = min_lat.min(south);
+            let new_max_lat = max_lat.max(north);
+
+            // Convert to intervals (handle crossing the antimeridian)
+            if west > east {
+                ranges.push((west, 180.0));
+                ranges.push((-180.0, east));
+            } else {
+                ranges.push((west, east));
+            }
+
+            (new_min_lat, new_max_lat, ranges)
+        },
+    )
+}
+
+fn merge_lng_rangesog(ranges: &mut [(f64, f64)]) -> Vec<(f64, f64)> {
+    if ranges.is_empty() {
+        return Vec::new();
+    }
+    if ranges.len() == 1 {
+        return vec![ranges[0]];
+    }
+
+    // sort by start... bc we gotta if there are more than one...
+    ranges.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    // init and add first one...
+    let mut merged = Vec::with_capacity(ranges.len());
+    merged.push(ranges[0]);
+
+    // fold fold fold
+    ranges[1..].iter().fold(merged, |mut acc, &(start, end)| {
+
+        if let Some((_prev_start, prev_end)) = acc.last_mut() {
+            // diff between
+            let abs_diff = (start - *prev_end).abs();
+            if abs_diff <= 1.0 {
+                *prev_end = prev_end.max(end);
+            // } else
+            // if start <= *prev_end - f64::EPSILON{
+            // if start <= *prev_end {
+                // this is the overlap... and that `*` is derefing I think
+                // so we're updating the end of the last interval in the acc
+                // to be the max of the end of the last interval and the
+                // end of the current interval
+                *prev_end = prev_end.max(end);
+            } else {
+                acc.push((start, end));
+            }
+        }
+
+        // gotta return the acc which I forgot to do and was tearing my hair out
+        // for a while... over this... super... dumb... mistake...
+        acc
+    })
+}
+/// Finds the largest gap on the circular [-180..180] domain
+/// among the merged intervals, returning (`gap_start`, `gap_end`).
+///
+/// The intervals here are non-overlapping and sorted.
+/// The "largest gap" is the segment NOT covered by intervals.
+fn largest_lng_range_hole(merged: &[(f64, f64)]) -> (f64, f64) {
+    if merged.is_empty() {
+        return (0.0, 0.0);
+    }
+    let (largest_gap, gap_start, gap_end) = merged.windows(2).fold(
+        (-1.0, 0.0, 0.0), // (acc_gap_size, acc_gap_start, acc_gap_end) initial
+        |(acc_gap, acc_start, acc_end), w| {
+            let curr_end = w[0].1; // end of the first interval
+            let next_start = w[1].0; // start of the next interval
+            let gap_size = next_start - curr_end;
+            if gap_size > acc_gap {
+                (gap_size, curr_end, next_start)
+            } else {
+                (acc_gap, acc_start, acc_end)
+            }
+        },
+    );
+    let last_end = merged.last().unwrap_or(&(0.0, 0.0)).1;
+    let first_start = merged.first().unwrap_or(&(0.0, 0.0)).0;
+    let wrap_size = (first_start + 360.0) - last_end;
+    // if the wrap-around is bigger than the largest gap, then
+    // we return that instead
+    if wrap_size > largest_gap {
+        (last_end, first_start + 360.0)
+    } else {
+        (gap_start, gap_end)
+    }
+}
+
+/// Tests for the web_geo_bounds_union function.
+///
+/// I wrote this in python to start with and verified these w/ the python
+/// version which I dumped into geojson.io to verify visually with my eyeballs
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_single_normal() {
+        let input = vec![(100.0, -5.0, 120.0, 10.0)];
+        let bbox = web_geo_bounds_union(&input).unwrap();
+        assert_eq!(bbox, (100.0, -5.0, 120.0, 10.0));
+    }
+
+    #[test]
+    fn test_single_crossing_am() {
+        // The single box crosses the antimeridian (west > east).
+        // We should return exactly what was passed in.
+        let input = vec![(170.0, -10.0, -170.0, 5.0)];
+        let bbox = web_geo_bounds_union(&input).unwrap();
+        assert_eq!(bbox, (170.0, -10.0, -170.0, 5.0));
+    }
+
+    #[test]
+    fn test_multiple_merged() {
+        let input = vec![
+            (170.0, -10.0, -170.0, 10.0), // crosses AM
+            (-160.0, -20.0, -100.0, 5.0),
+            (120.0, -15.0, 160.0, 15.0),
+        ];
+        let bbox = web_geo_bounds_union(&input).unwrap();
+        let expected: TBounds = (120.0, -20.0, -100.0, 15.0);
+        assert_eq!(bbox, expected);
+    }
+
+    #[test]
+    fn test_two_not_crossing_antimeridian() {
+        let input = vec![(100.0, -5.0, 120.0, 10.0), (110.0, -10.0, 130.0, 5.0)];
+        let bbox = web_geo_bounds_union(&input).unwrap();
+        assert_eq!(bbox, (100.0, -10.0, 130.0, 10.0));
+    }
+
+    #[test]
+    fn test_no_bboxes() {
+        let input = vec![];
+        let bbox = web_geo_bounds_union(&input);
+        assert_eq!(bbox, None);
+    }
+}

--- a/crates/utiles/src/copy/pasta.rs
+++ b/crates/utiles/src/copy/pasta.rs
@@ -408,6 +408,12 @@ LIMIT 1;
         Ok(0)
     }
 
+    // pub(crate) async fn copy_tiles_attach(
+    //     &self,
+    //     dst_db: &MbtilesClientAsync,
+    // ) -> UtilesResult<usize> {
+    // }
+
     pub(super) async fn run(&self) -> UtilesResult<()> {
         warn!("mbtiles-2-mbtiles copy is a WIP");
         // doing preflight check
@@ -500,12 +506,7 @@ LIMIT 1;
             dst_db
                 .metadata_set(
                     "tileid",
-                    self.cfg
-                        .hash
-                        .unwrap_or_default()
-                        .to_string()
-                        .to_string()
-                        .as_str(),
+                    self.cfg.hash.unwrap_or_default().to_string().as_str(),
                 )
                 .await?;
         }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -4,7 +4,11 @@
 - [CLI](./cli.md)
   - [COMMANDS](./commands.md)
 - [PYTHON](./python.md)
-- [ZOOM-LEVELS](./zoom-levels.md)
+- [RELATED](./related.md)
+- [REFERENCE](./reference.md)
+  - [DEFINITIONS](./definitions.md)
+  - [ZOOM-LEVELS](./zoom-levels.md)
+
 
 ___
 

--- a/docs/src/definitions.md
+++ b/docs/src/definitions.md
@@ -1,0 +1,23 @@
+# Definitions
+
+**yup:** in the context of web-map-tiles `yup` means "y-up"; z/x/y tile servers serve tiles with `y-down` coordinates, while `mbtiles` and `geopackage` files store tiles as `y-up`. Converting between `y` and `yup` is done by `yup = 2^z - y - 1` where `z` is the zoom level. Converting in a `sqlite` database can be done like this:
+
+```sql
+SELECT zoom_level AS z,
+       tile_column AS x,
+       (2^zoom_level - tile_row - 1) AS y, 
+       tile_row AS yup,
+FROM tiles;
+```
+
+**zoom-level:** Map zoom level 0 - 30
+
+**tile:** A tile is a square image of a specific zoom level, typically 256x256 pixels. Tiles are used to display map data at different zoom levels.
+
+**zbox:** Utiles name for a tile-bounding-box at a zoom level - defines zoom, min-x, min-y, max-x, max-y for querying tiles
+
+**tilejson:** A JSON object that describes a tile set, including its name, description, and the URL template for accessing tiles. TileJSON is used to provide metadata about a tile set.
+
+**textiles:** utiles name for an ndjson/jsonl file containing tiles as arrays or objects (e.g. `[x, y, z]` or `{x: x, y: y, z: z}`)
+
+

--- a/docs/src/related.md
+++ b/docs/src/related.md
@@ -1,0 +1,31 @@
+# Related Tools & Resources
+
+## Mapping
+
+- [OSGeo/gdal](https://github.com/OSGeo/gdal) - Geospatial Data Abstraction Library - a monster of a library
+- [rasterio/rasterio](https://github.com/rasterio/rasterio) - pythonic GDAL bindings and much more!
+- [felt/tippecanoe](https://github.com/felt/tippecanoe) - A tool for building vector tilesets from large collections of GeoJSON features.
+- [onthegomap/planetiler](https://github.com/onthegomap/planetiler) - Flexible tool to build planet-scale vector tilesets from OpenStreetMap data fast
+- [mapbox/mercantile](https://github.com/mapbox/mercantile) - python map tiling library - what `utiles` started as a port of
+- [mapbox/supermercado](https://github.com/mapbox/supermercado) - mercantile extension(s) - utiles is able to do much of what supermercado can do
+- [turfjs/turf](https://github.com/Turfjs/turf) - A modular geospatial engine written in JavaScript and TypeScript
+- [maplibre/martin](https://github.com/maplibre/martin) - PostGIS/mbtiles/pmtiles server and tile generator + mbtiles utils
+
+### Font Glyphs & Sprites
+
+- [stadiamaps/sdf_font_tools](https://github.com/stadiamaps/sdf_font_tools) - A set of tools for generating SDF fonts for use with MapLibre/Mapbox
+- [jessekrubin/pbfont](https://github.com/jessekrubin/pbfont) - js/ts font glyph decoding/encoding/combining
+- [flother/spreet](https://github.com/flother/spreet) - A tool to generate sprite sheets from SVGs
+
+### Frontend
+
+- [maplibre/maplibre-gl-js](https://github.com/maplibre/maplibre-gl-js/) - The open-source fork of Mapbox GL JS.
+- [onthegomap/maplibre-contour](https://github.com/onthegomap/maplibre-contour) - A MapLibre plugin for rendering contour lines
+- [visgl/deck.gl](https://github.com/visgl/deck.gl) - WebGL2 powered visualization Framework
+- [visgl/react-map-gl](https://github.com/visgl/react-map-gl) - React + Maplibre/Mapbox
+
+### Specs
+
+- [mapbox/mbtiles-spec](https://github.com/mapbox/mbtiles-spec) - The MBTiles specification
+- [mapbox/tilejson-spec](https://github.com/mapbox/tilejson-spec) - The TileJSON specification
+- [mapbox/vector-tile-spec](https://github.com/mapbox/vector-tile-spec) - The vector tile specification


### PR DESCRIPTION
This pull request includes various updates and improvements to the `utiles` project, including dependency updates, new functionality, and documentation additions. The most important changes are grouped by theme as follows:

### Dependency Updates:
* Updated `async-sqlite` to version `0.5.0` with the same features.
* Updated `jiff` to version `0.2.0`.
* Updated `rusqlite` to version `0.33.0` with the same features.
* Updated `sqlite-hashes` to version `0.8.0` with the same features.
* Updated `strum` and `strum_macros` to version `0.27.0`.

### New Functionality:
* Added a new `wrap_lon` function to wrap longitude values to the range [-180, 180].
* Implemented `web_geo_bounds_union` function to compute a union bounding box that can cross the antimeridian.
* Added a conversion implementation from `BBox` to `(f64, f64, f64, f64)`.

### Documentation Additions:
* Added new sections for "RELATED" and "REFERENCE" in the documentation summary.
* Added a new `definitions.md` file with key definitions related to the project.
* Added a new `related.md` file listing related tools and resources.

### Code Refactoring:
* Moved macros from `lib.rs` to a new `macros.rs` file and cleaned up the `lib.rs` file. [[1]](diffhunk://#diff-c22c14202aaa7356695e10f1d7b94cb4c48f9ba5288f252e4d0b127e7119fc51R50) [[2]](diffhunk://#diff-b15746bc6f7ed71282e4503bc050120c5dd5162e044b91318aa36da1b7dfbe95R1-R34)
* Removed commented-out old code from `lnglat2tile_frac` function in `fns.rs`.

### Minor Changes:
* Added `pub use web_geo_bounds::web_geo_bounds_union` to the `lib.rs` file.
* Simplified the `metadata_set` call in `pasta.rs`.
* Added a placeholder for a new `copy_tiles_attach` function in `pasta.rs`.