### PR TITLE
fix: broken pipe for several commands

### DIFF
--- a/crates/utiles/src/cli/args.rs
+++ b/crates/utiles/src/cli/args.rs
@@ -35,6 +35,13 @@ fn about() -> String {
 }
 
 #[derive(Debug, Parser)]
+pub struct AboutArgs {
+    /// output `json`
+    #[arg(required = false, long, short, action = clap::ArgAction::SetTrue,)]
+    pub json: bool,
+}
+
+#[derive(Debug, Parser)]
 #[command(name = "ut", about = about(), version = VERSION, author, max_term_width = 120)]
 pub struct Cli {
     /// debug mode (print/log more)
@@ -552,7 +559,7 @@ pub enum Commands {
     // colleagues who would otherwise have no idea what I'm talking about
     /// Echo info about utiles
     #[command(name = "about", visible_alias = "aboot")]
-    About,
+    About(AboutArgs),
 
     /// list all commands
     #[command(name = "commands", visible_alias = "cmds")]

--- a/crates/utiles/src/cli/commands/about.rs
+++ b/crates/utiles/src/cli/commands/about.rs
@@ -1,6 +1,7 @@
+use crate::cli::args::AboutArgs;
 use crate::errors::UtilesResult;
 
-pub(crate) fn about_main() -> UtilesResult<()> {
+pub(crate) fn about_main(args: &AboutArgs) -> UtilesResult<()> {
     let current_exe =
         std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("unknown"));
     let prof = if cfg!(debug_assertions) {
@@ -8,20 +9,26 @@ pub(crate) fn about_main() -> UtilesResult<()> {
     } else {
         "release"
     };
-    // if (json){
-    //     let j = serde_json::json! ({
-    //         "name": env!("CARGO_PKG_NAME"),
-    //         "version": env!("CARGO_PKG_VERSION"),
-    //         "authors": env!("CARGO_PKG_AUTHORS"),
-    //         "desc": env!("CARGO_PKG_DESCRIPTION"),
-    //         "repo": env!("CARGO_PKG_REPOSITORY"),
-    //         "which": current_exe.display().to_string(),
-    //         "profile": prof,
+    let docs = "https://utiles.dev";
+    if args.json {
+        let authors_arr = env!("CARGO_PKG_AUTHORS")
+            .split(':')
+            .map(|s| s.trim().to_string())
+            .collect::<Vec<String>>();
+        let j = serde_json::json! ({
+            "name": env!("CARGO_PKG_NAME"),
+            "version": env!("CARGO_PKG_VERSION"),
+            "authors":  authors_arr,
+            "desc": env!("CARGO_PKG_DESCRIPTION"),
+            "repo": env!("CARGO_PKG_REPOSITORY"),
+            "which": current_exe.display().to_string(),
+            "profile": prof,
+            "docs": docs,
 
-    //     });
-    //     println!("{}", serde_json::to_string_pretty(&j)?);
-    //     return Ok(());
-    // }
+        });
+        println!("{}", serde_json::to_string_pretty(&j)?);
+        return Ok(());
+    }
 
     let parts = [
         format!("{} ~ {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION")),
@@ -31,6 +38,7 @@ pub(crate) fn about_main() -> UtilesResult<()> {
         format!("repo:    {}", env!("CARGO_PKG_REPOSITORY")),
         format!("which:   {}", current_exe.display()),
         format!("profile: {prof}"),
+        format!("docs:    {docs}"),
     ];
     println!("{}", parts.join("\n"));
     Ok(())

--- a/crates/utiles/src/cli/commands/agg_hash.rs
+++ b/crates/utiles/src/cli/commands/agg_hash.rs
@@ -21,6 +21,6 @@ pub(crate) async fn agg_hash_main(args: &AggHashArgs) -> UtilesResult<()> {
     let hash_type = args.hash.unwrap_or(HashType::Md5);
     let filter = args.filter_args.tiles_filter_maybe();
     let result = mbt_agg_tiles_hash_stream(&mbt, hash_type, None, &filter).await?;
-    println!("{}", serde_json::to_string_pretty(&result)?);
+    safe_println!("{}", serde_json::to_string_pretty(&result)?);
     Ok(())
 }

--- a/crates/utiles/src/cli/commands/burn.rs
+++ b/crates/utiles/src/cli/commands/burn.rs
@@ -20,7 +20,7 @@ pub(crate) async fn burn_main(args: BurnArgs) -> UtilesResult<()> {
     let tiles = geojson2tiles(&geojson, args.zoom, None)?;
     for (i, tile) in tiles.iter().enumerate() {
         let rs = if args.fmtopts.seq { "\x1e\n" } else { "" };
-        println!("{}{}", rs, tile.json_arr());
+        safe_println!("{}{}", rs, tile.json_arr());
         if i % 2048 == 0 {
             asleep0!();
         }

--- a/crates/utiles/src/cli/commands/children_parent.rs
+++ b/crates/utiles/src/cli/commands/children_parent.rs
@@ -14,7 +14,7 @@ pub(crate) fn parent_main(args: ParentChildrenArgs) -> UtilesResult<()> {
         assert!(nup >= 0, "depth must be less than or equal to tile zoom");
         if let Some(parent) = tile.parent(Option::from(args.depth - 1)) {
             let rs = if args.fmtopts.seq { "\x1e\n" } else { "" };
-            println!("{}{}", rs, parent.json_arr());
+            safe_println!("{}{}", rs, parent.json_arr());
         }
     }
     Ok(())
@@ -30,7 +30,7 @@ pub(crate) fn children_main(args: ParentChildrenArgs) -> UtilesResult<()> {
 
         let children = tile_zbox.into_iter().map(Tile::from);
         for child in children {
-            println!("{}{}", rs, child.json_arr());
+            safe_println!("{}{}", rs, child.json_arr());
         }
     }
     Ok(())

--- a/crates/utiles/src/cli/commands/contains.rs
+++ b/crates/utiles/src/cli/commands/contains.rs
@@ -26,6 +26,6 @@ pub(crate) async fn contains_main(filepath: &str, lnglat: LngLat) -> UtilesResul
     let bbox = mbtiles.bbox().await?;
     let contains = bbox.contains_lnglat(&lnglat);
     debug!("contains: {contains}");
-    println!("{contains}");
+    safe_println!("{contains}");
     Ok(())
 }

--- a/crates/utiles/src/cli/commands/edges.rs
+++ b/crates/utiles/src/cli/commands/edges.rs
@@ -20,13 +20,13 @@ pub(crate) async fn edges_main(args: EdgesArgs) -> UtilesResult<()> {
 
         for tile in titer {
             let rs = if args.fmtopts.seq { "\x1e\n" } else { "" };
-            println!("{}{}", rs, tile.json_arr());
+            safe_println!("{}{}", rs, tile.json_arr());
         }
     } else {
         let titer = find_edges(&tiles)?;
         for tile in titer {
             let rs = if args.fmtopts.seq { "\x1e\n" } else { "" };
-            println!("{}{}", rs, tile.json_arr());
+            safe_println!("{}{}", rs, tile.json_arr());
         }
     }
     Ok(())

--- a/crates/utiles/src/cli/commands/merge.rs
+++ b/crates/utiles/src/cli/commands/merge.rs
@@ -26,13 +26,13 @@ pub(crate) async fn merge_main(args: MergeArgs) -> UtilesResult<()> {
         for tile in sorted_tiles {
             let rs = if args.fmtopts.seq { "\x1e\n" } else { "" };
             let tile_str = tile_formatter.fmt(tile);
-            println!("{rs}{tile_str}");
+            safe_println!("{rs}{tile_str}");
         }
     } else {
         for tile in merged_tiles {
             let rs = if args.fmtopts.seq { "\x1e\n" } else { "" };
             let tile_str = tile_formatter.fmt(&tile);
-            println!("{rs}{tile_str}");
+            safe_println!("{rs}{tile_str}");
         }
     }
     Ok(())

--- a/crates/utiles/src/lib.rs
+++ b/crates/utiles/src/lib.rs
@@ -23,6 +23,9 @@ pub use core::*;
 pub use errors::UtilesError;
 pub use errors::UtilesResult;
 
+#[macro_use]
+pub mod print;
+
 #[cfg(feature = "cli")]
 pub mod cli;
 mod config;

--- a/crates/utiles/src/print.rs
+++ b/crates/utiles/src/print.rs
@@ -1,0 +1,54 @@
+//! `safe_print!` and `safe_println!` macros
+//!
+//! REF: <https://github.com/rust-lang/rust/blob/master/compiler/rustc_driver_impl/src/print.rs>
+use std::fmt;
+use std::io::{self, Write as _};
+//
+// #[macro_export]
+// macro_rules! safe_print {
+//     ($($arg:tt)*) => {{
+//         $crate::print::print(std::format_args!($($arg)*));
+//     }};
+// }
+//
+// #[macro_export]
+// macro_rules! safe_println {
+//     ($($arg:tt)*) => {
+//         $crate::print::safe_print!("{}\n", std::format_args!($($arg)*));
+//     };
+// }
+macro_rules! safe_print {
+    ($($arg:tt)*) => {{
+        #[allow(clippy::unwrap_used)]
+        $crate::print::print(std::format_args!($($arg)*)) .unwrap();
+    }};
+}
+
+macro_rules! safe_println {
+    ($($arg:tt)*) => {
+        safe_print!("{}\n", std::format_args!($($arg)*))
+    };
+}
+pub fn print(args: fmt::Arguments<'_>) -> Result<(), io::Error> {
+    if let Err(err) = io::stdout().write_fmt(args) {
+        if err.kind() == io::ErrorKind::BrokenPipe {
+            // This is a common error when the output is piped to a command that exits
+            // before this process finishes writing. We can ignore it.
+            Ok(())
+        } else if err.kind() == io::ErrorKind::WriteZero {
+            // This error indicates that the write buffer is full and we can't write to it.
+            // We can ignore it as well.
+            Ok(())
+        } else {
+            // For any other error, we should panic.
+            Err(io::Error::new(
+                err.kind(),
+                format!("Error writing to stdout: {err}"),
+            ))
+        }
+    } else {
+        // Flush the output to ensure it is written immediately.
+        io::stdout().flush()?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
## AI WORD SALAD

This pull request includes several changes to improve the command-line interface (CLI) functionality and enhance the output handling in the `utiles` crate. The most important changes include adding support for JSON output in the `about` command, replacing `println!` with `safe_println!` for safer output handling, and adding detailed tracing in the CLI entry point.

Enhancements to CLI functionality:

* [`crates/utiles/src/cli/args.rs`](diffhunk://#diff-bdf2793041aebab830240e0f0969e3a93c7db2badae6795af4989fbde945e784R37-R43): Introduced `AboutArgs` struct to support JSON output in the `about` command and modified the `Commands` enum to use `AboutArgs`. [[1]](diffhunk://#diff-bdf2793041aebab830240e0f0969e3a93c7db2badae6795af4989fbde945e784R37-R43) [[2]](diffhunk://#diff-bdf2793041aebab830240e0f0969e3a93c7db2badae6795af4989fbde945e784L555-R562)

* [`crates/utiles/src/cli/commands/about.rs`](diffhunk://#diff-ff080fe45aa53c02b128c6fdaf3d1be807b4c880a1f6030fc5df1a77036b5440R1-R31): Updated the `about_main` function to accept `AboutArgs` and added logic to handle JSON output. [[1]](diffhunk://#diff-ff080fe45aa53c02b128c6fdaf3d1be807b4c880a1f6030fc5df1a77036b5440R1-R31) [[2]](diffhunk://#diff-ff080fe45aa53c02b128c6fdaf3d1be807b4c880a1f6030fc5df1a77036b5440R41)

Improved output handling:

* [`crates/utiles/src/print.rs`](diffhunk://#diff-76a16a170a35a76693a8a7a39761a5d805e5f52bb835a1eb1ebee5660deaff5dR1-R54): Added `safe_print!` and `safe_println!` macros to handle output safely, avoiding issues with broken pipes and write buffer errors.
* Replaced `println!` with `safe_println!` in various command implementations (`agg_hash`, `burn`, `parent`, `children`, `contains`, `edges`, `merge`). [[1]](diffhunk://#diff-9da36b06768d4f29a37e72ecb28aa18f16e661ca9d1782d37b6bf27311da8bc7L24-R24) [[2]](diffhunk://#diff-ff9b57ec98d2b91b17cac3cf55ccf88c94f44f7aae88bac1ad86f9a2756a4b08L23-R23) [[3]](diffhunk://#diff-717c0236f425d518e0b03809ad9484226c514a90d50f2d99f4c99c3530eb5c05L17-R17) [[4]](diffhunk://#diff-717c0236f425d518e0b03809ad9484226c514a90d50f2d99f4c99c3530eb5c05L33-R33) [[5]](diffhunk://#diff-a26c6af9199935a16e5cb194ccedee40dec0b709db14f043a6853465f824e7dcL29-R29) [[6]](diffhunk://#diff-6fecd5ff45d1121a8323658c2911ff8a72d4696f2d81de17812db5c47269a03dL23-R29) [[7]](diffhunk://#diff-b6e08e985274b31e805500d7117ba21fb854ef15723a16929aaf31e0a8c7f980L29-R35)

Enhanced tracing:

* [`crates/utiles/src/cli/entry.rs`](diffhunk://#diff-a80dd0d2ce48772cb792d489e4176221f59446678f6cda6e1fe839cc1c4dffb5L15-R15): Added detailed tracing for command-line arguments and execution time in the `cli_main_inner` function. [[1]](diffhunk://#diff-a80dd0d2ce48772cb792d489e4176221f59446678f6cda6e1fe839cc1c4dffb5L15-R15) [[2]](diffhunk://#diff-a80dd0d2ce48772cb792d489e4176221f59446678f6cda6e1fe839cc1c4dffb5L117-R124) [[3]](diffhunk://#diff-a80dd0d2ce48772cb792d489e4176221f59446678f6cda6e1fe839cc1c4dffb5L166-R171)