### PR TITLE
insert-strategy for stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -144,9 +144,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-compression"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d615619615a650c571269c00dca41db04b9210037fa76ed8239f70404ab56985"
+checksum = "40f6024f3f856663b45fd0c9b6f2024034a702f453549449e0d84a305900dad4"
 dependencies = [
  "flate2",
  "futures-core",
@@ -177,7 +177,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -294,7 +294,7 @@ checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -417,9 +417,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.26"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -501,7 +501,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -680,7 +680,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -721,7 +721,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -914,7 +914,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1075,9 +1075,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1255,7 +1255,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1326,7 +1326,7 @@ checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1406,9 +1406,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libdeflate-sys"
@@ -1540,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
@@ -1656,7 +1656,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1813,7 +1813,7 @@ dependencies = [
  "regex",
  "regex-syntax 0.8.5",
  "structmeta",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1954,7 +1954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
 dependencies = [
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2003,7 +2003,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2016,7 +2016,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2061,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radium"
@@ -2173,9 +2173,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -2329,7 +2329,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2444,12 +2444,9 @@ checksum = "1b6709c7b6754dca1311b3c73e79fcce40dd414c782c66d88e8823030093b02b"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"
@@ -2495,7 +2492,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2506,7 +2503,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2528,7 +2525,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2553,9 +2550,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.102"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2635,7 +2632,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2646,17 +2643,16 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -2672,9 +2668,9 @@ dependencies = [
 
 [[package]]
 name = "tilejson"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b6778ebff37ae1c897c9ca86d095f00ce089b7506fb42b7601ef339c8d415d"
+checksum = "09df9bd16a6684e8c9962ef4a2e19c42fe21424c55ee99d71ebc55935a2f1eb6"
 dependencies = [
  "serde",
  "serde_json",
@@ -2718,7 +2714,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2843,13 +2839,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3162,7 +3158,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -3184,7 +3180,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3372,22 +3368,22 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ hex = "0.4.3"
 image = "0.25.6"
 imagesize = "0.14.0"
 indicatif = "0.17.11"
-indoc = "2.0.5"
+indoc = "2.0.6"
 jiff = "0.2.15"
 json-patch = "4.0.0"
 md-5 = "0.10.6"
@@ -51,17 +51,17 @@ noncrypto-digests = "0.3.6"
 num_cpus = "1.17.0"
 owo-colors = { version = "4.2.1", features = ["supports-color"] }
 pmtiles = { version = "0.14.0", features = ["mmap-async-tokio", "tilejson"] }
-pyo3 = "0.25.1"
-pyo3-build-config = "0.25.0"
+pyo3 = "0.25"
+pyo3-build-config = "0.25"
 rusqlite = { version = "0.36.0", features = ["bundled", "vtab", "blob"] }
-serde = { version = "1.0.208", features = ["derive"] }
+serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140", features = ["preserve_order"] }
 size = { version = "0.5.0", features = ["default"] }
 sqlite-hashes = { version = "0.10.6", default-features = false, features = ["hex", "md5", "fnv", "xxhash"] }
 strum = { version = "0.27.1", features = ["derive"] }
 strum_macros = "0.27.1"
 thiserror = "2.0.12"
-tilejson = "0.4.2"
+tilejson = "0.4.3"
 tokio = { version = "1.45", features = ["full"] }
 tokio-stream = "0.1.17"
 tower = { version = "0.5.2", features = ["timeout"] }

--- a/crates/utiles-doubledown/src/main.rs
+++ b/crates/utiles-doubledown/src/main.rs
@@ -28,6 +28,7 @@ use utiles::lager::{init_tracing, LagerConfig, LagerLevel};
 use utiles::mbt::{
     MbtStreamWriterSync, MbtWriterStats, MbtilesAsync, MbtilesClientAsync,
 };
+use utiles::sqlite::InsertStrategy;
 use utiles::Tile;
 
 #[derive(Debug, Parser)]
@@ -243,6 +244,7 @@ async fn utiles_doubledown_main(args: Cli) -> anyhow::Result<()> {
     // mbt-writer stream....
     let mut writer = MbtStreamWriterSync {
         stream: ReceiverStream::new(rx_writer),
+        on_conflict: InsertStrategy::None,
         mbt: dst,
         stats: MbtWriterStats::default(),
     };

--- a/crates/utiles-oxipng/src/main.rs
+++ b/crates/utiles-oxipng/src/main.rs
@@ -7,6 +7,7 @@ use tokio::join;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, error, info, warn};
 use utiles::internal::cli_tools::open_new_overwrite;
+use utiles::sqlite::InsertStrategy;
 use utiles::tile_type::TileFormat;
 use utiles::{
     lager::{init_tracing, LagerConfig, LagerLevel},
@@ -91,6 +92,7 @@ async fn oxipng_main(args: Cli) -> anyhow::Result<()> {
     let mut writer = MbtStreamWriterSync {
         stream: ReceiverStream::new(rx_writer),
         mbt: dst_mbtiles,
+        on_conflict: InsertStrategy::None,
         stats: MbtWriterStats::default(),
     };
     let jobs: usize = args.jobs.unwrap_or(4) as usize;

--- a/crates/utiles/src/cli/commands/webpify.rs
+++ b/crates/utiles/src/cli/commands/webpify.rs
@@ -10,6 +10,7 @@ use crate::cli::args::WebpifyArgs;
 use crate::img::webpify_image;
 use crate::mbt::{MbtStreamWriterSync, MbtWriterStats};
 use crate::mbt::{Mbtiles, MbtilesAsync, MbtilesClientAsync};
+use crate::sqlite::InsertStrategy;
 use crate::UtilesResult;
 
 pub(crate) async fn webpify_main(args: WebpifyArgs) -> UtilesResult<()> {
@@ -28,6 +29,7 @@ pub(crate) async fn webpify_main(args: WebpifyArgs) -> UtilesResult<()> {
     let mut writer = MbtStreamWriterSync {
         stream: ReceiverStream::new(rx_writer),
         mbt: dst_mbtiles,
+        on_conflict: InsertStrategy::None,
         stats: MbtWriterStats::default(),
     };
     let jobs: usize = args.jobs.unwrap_or(4) as usize;

--- a/crates/utiles/src/copy/pasta.rs
+++ b/crates/utiles/src/copy/pasta.rs
@@ -394,6 +394,7 @@ LIMIT 1;
         let mut writer = MbtStreamWriterSync {
             mbt: dst_mbt_sync,
             stream: ReceiverStream::new(rx),
+            on_conflict: self.cfg.istrat,
             stats: MbtWriterStats::default(),
         };
         let write_task = writer.write();


### PR DESCRIPTION
- insert strategy for copy via stream

# ai word salad

This pull request introduces a new `InsertStrategy` configuration to manage database insert conflict resolution in the `MbtStreamWriterSync` struct and its associated methods. Additionally, it updates dependencies in `Cargo.toml` and applies the new `InsertStrategy` functionality across multiple modules. Below is a summary of the most important changes:

### Enhancements to `MbtStreamWriterSync` for Conflict Resolution:
* Added a new `on_conflict` field to the `MbtStreamWriterSync` struct to specify the `InsertStrategy` (e.g., `Ignore`, `Replace`, etc.) for database insert operations. (`crates/utiles/src/mbt/stream_writer.rs`, [crates/utiles/src/mbt/stream_writer.rsR34](diffhunk://#diff-90b12b80148866f6e8cbcf032e32b372c572a41bba663a728f396ff3230aabd5R34))
* Updated `write_flat`, `write_hash`, and `write_norm` methods to dynamically generate SQL statements based on the `InsertStrategy` value, ensuring flexible conflict handling for tile data insertions. (`crates/utiles/src/mbt/stream_writer.rs`, [[1]](diffhunk://#diff-90b12b80148866f6e8cbcf032e32b372c572a41bba663a728f396ff3230aabd5L68-R87) [[2]](diffhunk://#diff-90b12b80148866f6e8cbcf032e32b372c572a41bba663a728f396ff3230aabd5L98-R132) [[3]](diffhunk://#diff-90b12b80148866f6e8cbcf032e32b372c572a41bba663a728f396ff3230aabd5L125-R175)

### Application of `InsertStrategy` Across Modules:
* Integrated `InsertStrategy::None` as the default value for `on_conflict` in `MbtStreamWriterSync` instances across various modules (`utiles-doubledown`, `utiles-oxipng`, and `webpify`). (`crates/utiles-doubledown/src/main.rs`, [[1]](diffhunk://#diff-3ad1009a279da9e8535cb5e9f8c4ccdba48a93d6ad9ad859486f361b98edb054R247); `crates/utiles-oxipng/src/main.rs`, [[2]](diffhunk://#diff-3048a633b74a452c51115ace2334e6d3fd8ff4325018cf2e3f3147eaa9ecdaa6R95); `crates/utiles/src/cli/commands/webpify.rs`, [[3]](diffhunk://#diff-bae25b039d30865acdac902221307a2e499e4e53d87bdc5eac2d43e7a0186dd2R32)
* Added `InsertStrategy` imports to modules using `MbtStreamWriterSync`. (`crates/utiles-doubledown/src/main.rs`, [[1]](diffhunk://#diff-3ad1009a279da9e8535cb5e9f8c4ccdba48a93d6ad9ad859486f361b98edb054R31); `crates/utiles-oxipng/src/main.rs`, [[2]](diffhunk://#diff-3048a633b74a452c51115ace2334e6d3fd8ff4325018cf2e3f3147eaa9ecdaa6R10); `crates/utiles/src/cli/commands/webpify.rs`, [[3]](diffhunk://#diff-bae25b039d30865acdac902221307a2e499e4e53d87bdc5eac2d43e7a0186dd2R13)

### Dependency Updates:
* Updated several dependencies in `Cargo.toml`, including `indoc`, `pyo3`, `serde`, and `tilejson`, to newer versions for improved compatibility and performance. (`Cargo.toml`, [Cargo.tomlL46-R64](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L46-R64))

### Other Changes:
* Integrated `on_conflict` configuration into a writer instance in `pasta.rs` to align with the new `InsertStrategy` functionality. (`crates/utiles/src/copy/pasta.rs`, [crates/utiles/src/copy/pasta.rsR397](diffhunk://#diff-ebcb4838ae317be1dcb0ec7e4bc97366939f8d8031e3e7e0ccf2f6de80d8eb74R397))

These changes enhance the flexibility of database operations while ensuring compatibility with updated dependencies. Let me know if you need further clarification or assistance!